### PR TITLE
Deprecate repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Deprecation notice
+This module is deprecated. Use the `subprocess` module instead.
+
 # common_helper_process
 [![Build Status](https://travis-ci.org/fkie-cad/common_helper_process.svg?branch=master)](https://travis-ci.org/fkie-cad/common_helper_process)
 [![codecov](https://codecov.io/gh/fkie-cad/common_helper_process/branch/master/graph/badge.svg)](https://codecov.io/gh/fkie-cad/common_helper_process)


### PR DESCRIPTION
Depends on https://github.com/fkie-cad/FACT_core/pull/730.
We should probably archive this repo after merging.